### PR TITLE
feat(multilevel-config): support multilevel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,10 @@ Parses a parameter string of the format key1=value1&key2=value2, optionally conv
 If the value types are to be converted, true and false are converted to booleans irrespective of case. Values are converted to numbers if they match the following regex ```/^[-+]?(\d+\.)?\d+(E[-+]?\d+)?$/i```.
 
 If you need finer control of value conversions, leave parseValues at false and handle the conversions in your driver code.
+
+If the driver supports multiple levels to the config object (like the MySQL driver), you can modify the `key` as follows:
+- `key1=value1&key2[subkey1]=value2` yields `{ key1: "value1", key2: { subkey1: "value2" } }`
+- `key1=value1&key2[subkey1][subsubkey1]=value2` yields `{ key1: "value1", key2: { subkey1: { subkey2: "value2" } } }`
+- `key1=value1&key2[]=value2` yields `{ key1: "value1", key2: [ "value2" ] }`
+- `key1=value1&key2[]=value2&key2[]=value3` yields `{ key1: "value1", key2: [ "value2", "value3" ] }`
+- `key1=value1&key2[0]=value2` yields `{ key1: "value1", key2: [ "value2" ] }`

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+var keyBreaker = /([^\[\]]+)|(\[\])/g,
+    digitTest = /^\d+$/;
+
 function parseConnectionParams(paramstring, parseValues = false) {
     const params = {};
     const numberRegex = /^[-+]?(\d+\.)?\d+(E[-+]?\d+)?$/i;
@@ -13,9 +16,25 @@ function parseConnectionParams(paramstring, parseValues = false) {
             } :
             (value) => value;
 
+        // based on $.String.deparam: https://github.com/jupiterjs/jquerymx/blob/master/lang/string/deparam/deparam.js
         paramstring.split('&').map(s => {
             let [key, val] = s.split('=');
-            params[key] = valuesPreprocessor(val);
+            let current = params;
+            let parts = key.match(keyBreaker);
+            for(var i = 0; i < parts.length - 1; i++) {
+                let part = parts[i];
+                if(!current[part]) {
+                    // if what we are pointing to looks like an array
+                    current[part] = digitTest.test(parts[i+1]) || parts[i+1] == "[]" ? [] : {}
+                }
+                current = current[part];
+            }
+            let lastPart = parts[parts.length - 1];
+            if(lastPart == "[]"){
+                current.push(valuesPreprocessor(val));
+            } else {
+                current[lastPart] = valuesPreprocessor(val);
+            }
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "database-js-common",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "database-js common code",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,6 +3,8 @@ const assert = require('assert');
 describe('Test parseConnectionParams method', function () {
     const parseConnectionParams = require('../.').parseConnectionParams;
     const testedParamString = 'booleanTrue=true&booleanFalse=false&string=foo&integer=35&float=35.8';
+    const testedSingleNestedObjectString = 'subkey[string]=foo&subkey[booleanTrue]=true&subkey[booleanFalse]=false&subkey[integer]=42&subkey[float]=98.6&array[0]=0&array[1]=98.6&array2[]=0&array2[]=98.6';
+    const testedMultiNestedObjectString = 'subkey[subkey][string]=foo&subkey[subkey][booleanTrue]=true&subkey[subkey][booleanFalse]=false&subkey[subkey][integer]=42&subkey[subkey][float]=98.6&subkey[subkey][array][]=0&subkey[subkey][array][]=98.6&array[0][0]=0&array[0][1]=98.6&array[1][]=0&array[1][]=98.6';
 
     describe('Test default not parsed values', function () {
         const result = parseConnectionParams(testedParamString);
@@ -61,5 +63,110 @@ describe('Test parseConnectionParams method', function () {
         it('should be float', function () {
             assert.equal(result.float, 35.8)
         });
-    })
+    });
+
+    describe('Test parsing single-level nested objects', function () {
+        const result = parseConnectionParams(testedSingleNestedObjectString, true);
+
+        it('should be parsed', function () {
+            assert.ok(typeof result === 'object', 'result not parsed');
+        });
+
+        it('should have object subkey', function () {
+            assert.ok(typeof result.subkey === 'object', 'result subkey is not an object');
+        });
+
+        it('subkey should be boolean true', function () {
+            assert.equal(result.subkey.booleanTrue, true);
+        });
+
+        it('subkey should be boolean false', function () {
+            assert.equal(result.subkey.booleanFalse, false);
+        });
+
+        it('subkey should be string', function () {
+            assert.equal(result.subkey.string, 'foo');
+        });
+
+        it('subkey should be integer', function () {
+            assert.equal(result.subkey.integer, 42);
+        });
+
+        it('subkey should be float', function () {
+            assert.equal(result.subkey.float, 98.6);
+        });
+
+        it('should have array subkey', function () {
+            assert.ok(result.array.constructor === Array, 'result array is not an array');
+        });
+
+        it('array length should be 2', function () {
+            assert.equal(result.array.length, 2);
+        });
+
+        it('array item should be integer', function () {
+            assert.equal(result.array[0], 0);
+        });
+
+        it('array item should be float', function () {
+            assert.equal(result.array[1], 98.6);
+        });
+
+        it('should have array2 subkey', function () {
+            assert.ok(result.array2.constructor === Array, 'result array2 is not an array');
+        });
+
+        it('array2 length should be 2', function () {
+            assert.equal(result.array2.length, 2);
+        });
+
+        it('array2 item should be integer', function () {
+            assert.equal(result.array2[0], 0);
+        });
+
+        it('array2 item should be float', function () {
+            assert.equal(result.array2[1], 98.6);
+        });
+    });
+
+    describe('Test parsing multi-level nested objects', function () {
+        const result = parseConnectionParams(testedMultiNestedObjectString, true);
+
+        it('should be parsed', function () {
+            assert.ok(typeof result === 'object', 'result not parsed');
+        });
+
+        it('should have object subkey', function () {
+            assert.ok(typeof result.subkey === 'object', 'result subkey is not an object');
+        });
+
+        it('should have object subkey object subkey', function () {
+            assert.ok(typeof result.subkey.subkey === 'object', 'result subkey subkey is not an object');
+        });
+
+        it('subkey should be boolean true', function () {
+            assert.equal(result.subkey.subkey.booleanTrue, true);
+        });
+
+        it('subkey should be boolean false', function () {
+            assert.equal(result.subkey.subkey.booleanFalse, false);
+        });
+
+        it('subkey should be string', function () {
+            assert.equal(result.subkey.subkey.string, 'foo');
+        });
+
+        it('subkey should be integer', function () {
+            assert.equal(result.subkey.subkey.integer, 42);
+        });
+
+        it('subkey should be float', function () {
+            assert.equal(result.subkey.subkey.float, 98.6);
+        });
+
+        it('subkey should be array', function () {
+            assert.ok(result.subkey.subkey.array.constructor === Array, 'result subkey array is not an array');
+        });
+    });
+
 });


### PR DESCRIPTION
Adds support for multilevel objects and arrays to the query string
parsing. For example, the string
`ssl[ca]=ca.pem&ssl[key]=key.pem&ssl[cert]=cert.pem` would parse to:

```
{
  ssl: {
    ca: 'ca.pem',
    key: 'key.pem',
    cert: 'cert.pem'
  }
}
```